### PR TITLE
Feat: Oauth 로그인 기능 추가 (kakao,naver)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ out/
 .vscode/
 
 application-*
-
+application.properties
 build

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/CaffeineCoder/recipic/domain/User/api/UserApi.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/User/api/UserApi.java
@@ -1,0 +1,30 @@
+package CaffeineCoder.recipic.domain.User.api;
+
+import CaffeineCoder.recipic.domain.authentication.domain.AuthTokensGenerator;
+import CaffeineCoder.recipic.domain.User.domain.User;
+import CaffeineCoder.recipic.domain.User.dao.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserApi {
+    private final UserRepository userRepository;
+    private final AuthTokensGenerator authTokensGenerator;
+
+    @GetMapping("/users")
+    public ResponseEntity<List<User>> findAll() {
+        return ResponseEntity.ok(userRepository.findAll());
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<User> findByAccessToken(@RequestParam("accessToken") String accessToken) {
+        Long userId = authTokensGenerator.extractUserId(accessToken);
+        System.out.println(userId);
+        return ResponseEntity.ok(userRepository.findById(userId).get());
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/User/dao/UserRepository.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/User/dao/UserRepository.java
@@ -1,0 +1,10 @@
+package CaffeineCoder.recipic.domain.User.dao;
+
+import CaffeineCoder.recipic.domain.User.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/User/domain/User.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/User/domain/User.java
@@ -1,0 +1,32 @@
+package CaffeineCoder.recipic.domain.User.domain;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    private String email;
+
+    private String nickname;
+
+    @Column(name = "o_auth_provider")
+    private OAuthProvider oAuthProvider;
+
+    @Builder
+    public User(String email, String nickname, OAuthProvider oAuthProvider) {
+        this.email = email;
+        this.nickname = nickname;
+        this.oAuthProvider = oAuthProvider;
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/api/AuthController.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/api/AuthController.java
@@ -1,0 +1,27 @@
+package CaffeineCoder.recipic.domain.authentication.api;
+
+import CaffeineCoder.recipic.domain.authentication.domain.AuthTokens;
+import CaffeineCoder.recipic.domain.authentication.infra.kakao.KakaoLoginParams;
+import CaffeineCoder.recipic.domain.authentication.infra.naver.NaverLoginParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final OAuthLoginService oAuthLoginService;
+
+    @PostMapping("/kakao")
+    public ResponseEntity<AuthTokens> loginKakao(@RequestBody KakaoLoginParams params) {
+        return ResponseEntity.ok(oAuthLoginService.login(params));
+    }
+
+    @PostMapping("/naver")
+    public ResponseEntity<AuthTokens> loginNaver(@RequestBody NaverLoginParams params) {
+        return ResponseEntity.ok(oAuthLoginService.login(params));
+    }
+
+
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/api/OAuthLoginService.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/api/OAuthLoginService.java
@@ -1,0 +1,41 @@
+package CaffeineCoder.recipic.domain.authentication.api;
+
+import CaffeineCoder.recipic.domain.authentication.domain.AuthTokens;
+import CaffeineCoder.recipic.domain.authentication.domain.AuthTokensGenerator;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthInfoResponse;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthLoginParams;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.RequestOAuthInfoService;
+import CaffeineCoder.recipic.domain.User.domain.User;
+import CaffeineCoder.recipic.domain.User.dao.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthLoginService {
+    private final UserRepository userRepository;
+    private final AuthTokensGenerator authTokensGenerator;
+    private final RequestOAuthInfoService requestOAuthInfoService;
+
+    public AuthTokens login(OAuthLoginParams params) {
+        OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
+        Long memberId = findOrCreateMember(oAuthInfoResponse);
+        return authTokensGenerator.generate(memberId);
+    }
+
+    private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
+        return userRepository.findByEmail(oAuthInfoResponse.getEmail())
+                .map(User::getUserId)
+                .orElseGet(() -> newMember(oAuthInfoResponse));
+    }
+
+    private Long newMember(OAuthInfoResponse oAuthInfoResponse) {
+        User user = User.builder()
+                .email(oAuthInfoResponse.getEmail())
+                .nickname(oAuthInfoResponse.getNickname())
+                .oAuthProvider(oAuthInfoResponse.getOAuthProvider())
+                .build();
+
+        return userRepository.save(user).getUserId();
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/config/ClientConfig.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/config/ClientConfig.java
@@ -1,0 +1,14 @@
+package CaffeineCoder.recipic.domain.authentication.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/AuthTokens.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/AuthTokens.java
@@ -1,0 +1,22 @@
+package CaffeineCoder.recipic.domain.authentication.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthTokens {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public static AuthTokens of(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        return new AuthTokens(accessToken, refreshToken, grantType, expiresIn);
+    }
+}
+

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/AuthTokensGenerator.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/AuthTokensGenerator.java
@@ -1,0 +1,33 @@
+package CaffeineCoder.recipic.domain.authentication.domain;
+
+import CaffeineCoder.recipic.domain.authentication.infra.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokensGenerator {
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthTokens generate(Long memberId) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiredAt = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+        String subject = memberId.toString();
+        String accessToken = jwtTokenProvider.generate(subject, accessTokenExpiredAt);
+        String refreshToken = jwtTokenProvider.generate(subject, refreshTokenExpiredAt);
+
+        return AuthTokens.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+    }
+
+    public Long extractUserId(String accessToken) {
+        return Long.valueOf(jwtTokenProvider.extractSubject(accessToken));
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthApiClient.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthApiClient.java
@@ -1,0 +1,7 @@
+package CaffeineCoder.recipic.domain.authentication.domain.oauth;
+
+public interface OAuthApiClient {
+    OAuthProvider oAuthProvider();
+    String requestAccessToken(OAuthLoginParams params);
+    OAuthInfoResponse requestOauthInfo(String accessToken);
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthInfoResponse.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthInfoResponse.java
@@ -1,0 +1,7 @@
+package CaffeineCoder.recipic.domain.authentication.domain.oauth;
+
+public interface OAuthInfoResponse {
+    String getEmail();
+    String getNickname();
+    OAuthProvider getOAuthProvider();
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthLoginParams.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthLoginParams.java
@@ -1,0 +1,8 @@
+package CaffeineCoder.recipic.domain.authentication.domain.oauth;
+
+import org.springframework.util.MultiValueMap;
+
+public interface OAuthLoginParams {
+    OAuthProvider oAuthProvider();
+    MultiValueMap<String, String> makeBody();
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthProvider.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/OAuthProvider.java
@@ -1,0 +1,5 @@
+package CaffeineCoder.recipic.domain.authentication.domain.oauth;
+
+public enum OAuthProvider {
+    KAKAO, NAVER
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/RequestOAuthInfoService.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/domain/oauth/RequestOAuthInfoService.java
@@ -1,0 +1,25 @@
+package CaffeineCoder.recipic.domain.authentication.domain.oauth;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestOAuthInfoService {
+    private final Map<OAuthProvider, OAuthApiClient> clients;
+
+    public RequestOAuthInfoService(List<OAuthApiClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuthApiClient::oAuthProvider, Function.identity())
+        );
+    }
+
+    public OAuthInfoResponse request(OAuthLoginParams params) {
+        OAuthApiClient client = clients.get(params.oAuthProvider());
+        String accessToken = client.requestAccessToken(params);
+        return client.requestOauthInfo(accessToken);
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/JwtTokenProvider.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/JwtTokenProvider.java
@@ -1,0 +1,47 @@
+package CaffeineCoder.recipic.domain.authentication.infra;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${jwt.secret-key}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generate(String subject, Date expiredAt) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setExpiration(expiredAt)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String extractSubject(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        return claims.getSubject();
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}
+

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoApiClient.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoApiClient.java
@@ -1,0 +1,73 @@
+package CaffeineCoder.recipic.domain.authentication.infra.kakao;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthApiClient;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthInfoResponse;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthLoginParams;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient implements OAuthApiClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${oauth.kakao.url.auth}")
+    private String authUrl;
+
+    @Value("${oauth.kakao.url.api}")
+    private String apiUrl;
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public String requestAccessToken(OAuthLoginParams params) {
+        String url = authUrl + "/oauth/token";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = params.makeBody();
+        body.add("grant_type", GRANT_TYPE);
+        body.add("client_id", clientId);
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        KakaoTokens response = restTemplate.postForObject(url, request, KakaoTokens.class);
+
+        assert response != null;
+        return response.getAccessToken();
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v2/user/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\", \"kakao_account.profile\"]");
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, KakaoInfoResponse.class);
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoInfoResponse.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoInfoResponse.java
@@ -1,0 +1,43 @@
+package CaffeineCoder.recipic.domain.authentication.infra.kakao;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthInfoResponse;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoInfoResponse implements OAuthInfoResponse {
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoAccount {
+        private KakaoProfile profile;
+        private String email;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoProfile {
+        private String nickname;
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return kakaoAccount.profile.nickname;
+    }
+
+    @Override
+    public OAuthProvider getOAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoLoginParams.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoLoginParams.java
@@ -1,0 +1,26 @@
+package CaffeineCoder.recipic.domain.authentication.infra.kakao;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthLoginParams;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginParams implements OAuthLoginParams {
+    private String authorizationCode;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.KAKAO;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoTokens.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/kakao/KakaoTokens.java
@@ -1,0 +1,28 @@
+package CaffeineCoder.recipic.domain.authentication.infra.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokens {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverApiClient.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverApiClient.java
@@ -1,0 +1,76 @@
+package CaffeineCoder.recipic.domain.authentication.infra.naver;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthApiClient;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthInfoResponse;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthLoginParams;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class NaverApiClient implements OAuthApiClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${oauth.naver.url.auth}")
+    private String authUrl;
+
+    @Value("${oauth.naver.url.api}")
+    private String apiUrl;
+
+    @Value("${oauth.naver.client-id}")
+    private String clientId;
+
+    @Value("${oauth.naver.secret}")
+    private String clientSecret;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.NAVER;
+    }
+
+    @Override
+    public String requestAccessToken(OAuthLoginParams params) {
+        String url = authUrl + "/oauth2.0/token";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = params.makeBody();
+        body.add("grant_type", GRANT_TYPE);
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        NaverTokens response = restTemplate.postForObject(url, request, NaverTokens.class);
+
+        assert response != null;
+        return response.getAccessToken();
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v1/nid/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, NaverInfoResponse.class);
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverInfoResponse.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverInfoResponse.java
@@ -1,0 +1,37 @@
+package CaffeineCoder.recipic.domain.authentication.infra.naver;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthInfoResponse;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverInfoResponse implements OAuthInfoResponse {
+
+    @JsonProperty("response")
+    private Response response;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Response {
+        private String email;
+        private String nickname;
+    }
+
+    @Override
+    public String getEmail() {
+        return response.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return response.nickname;
+    }
+
+    @Override
+    public OAuthProvider getOAuthProvider() {
+        return OAuthProvider.NAVER;
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverLoginParams.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverLoginParams.java
@@ -1,0 +1,28 @@
+package CaffeineCoder.recipic.domain.authentication.infra.naver;
+
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthLoginParams;
+import CaffeineCoder.recipic.domain.authentication.domain.oauth.OAuthProvider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@NoArgsConstructor
+public class NaverLoginParams implements OAuthLoginParams {
+    private String authorizationCode;
+    private String state;
+
+    @Override
+    public OAuthProvider oAuthProvider() {
+        return OAuthProvider.NAVER;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        body.add("state", state);
+        return body;
+    }
+}

--- a/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverTokens.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/authentication/infra/naver/NaverTokens.java
@@ -1,0 +1,22 @@
+package CaffeineCoder.recipic.domain.authentication.infra.naver;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NaverTokens {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+}


### PR DESCRIPTION
PR 타입
 - [x] 기능 추가
 - [ ] 기능 삭제
 - [ ] 버그 수정
 - [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

반영 브랜치
feat/oauth ➡️ main

### 작업사항 📝
Oauth 로그인 기능 추가

신규 API 목록
1. `/api/auth/kakao`: kakao의 authorized token을 받아 accesstoken,refreshtoken 발급
2. `/api/auth/naver`: nvaer의 authorized token을 받아 accesstoken,refreshtoken 발급
1. `/api/user`: accesstoken을 통해 userid를 받는 API
2. `/api/users`: 유저 목록 반환

### 테스트 방법
kakao login base url : localhost:8080 
redirect url : localhost:8080/kakao/callback

### 관련 이슈
issue #3 

