### PR TITLE
Feat/recipe/list: 전체 레시피 반환 & 쿼리 기능 구현

### DIFF
--- a/src/main/java/CaffeineCoder/recipic/domain/brand/repository/BrandRepository.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/brand/repository/BrandRepository.java
@@ -2,6 +2,8 @@ package CaffeineCoder.recipic.domain.brand.repository;
 
 import CaffeineCoder.recipic.domain.brand.domain.Brand;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,7 @@ import java.util.Optional;
 @Repository
 public interface BrandRepository extends JpaRepository<Brand, Long> {
     Optional<Brand> findByBrandName(String brandName);
+
+    @Query("SELECT b.brandId FROM Brand b WHERE b.brandName = :name")
+    Optional<Integer> findBrandIdByBrandName(@Param("name") String name);
 }

--- a/src/main/java/CaffeineCoder/recipic/domain/recipe/api/RecipeController.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/recipe/api/RecipeController.java
@@ -1,10 +1,11 @@
 package CaffeineCoder.recipic.domain.recipe.api;
 
 import CaffeineCoder.recipic.domain.recipe.application.RecipeService;
+import CaffeineCoder.recipic.domain.recipe.dto.RecipeResponseDto;
 import CaffeineCoder.recipic.domain.recipe.dto.RecipeRequestDto;
 import CaffeineCoder.recipic.global.response.ApiResponse;
 import CaffeineCoder.recipic.global.util.ApiUtils;
-import lombok.Getter;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,6 +31,15 @@ public class RecipeController {
     @GetMapping("/detail/{recipeId}")
     public ApiResponse<?> getRecipeDetail(@PathVariable("recipeId") Integer recipeId) {
         return ApiUtils.success(recipeService.getRecipeDetail(recipeId));
+    }
+
+    @GetMapping("/list")
+    public ApiResponse<?> getScraps(
+            @RequestParam(value = "keyword", defaultValue = "") String keyword,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+        System.out.printf("keyword: %s, page: %d, size: %d\n", keyword, page, size);
+        return ApiUtils.success(recipeService.getQueriedRecipes(keyword, page, size));
     }
 
 }

--- a/src/main/java/CaffeineCoder/recipic/domain/recipe/application/RecipeRankService.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/recipe/application/RecipeRankService.java
@@ -2,7 +2,7 @@ package CaffeineCoder.recipic.domain.recipe.application;
 
 import CaffeineCoder.recipic.domain.recipe.dao.RecipeRepository;
 import CaffeineCoder.recipic.domain.recipe.domain.Recipe;
-import CaffeineCoder.recipic.domain.recipe.dto.RecipeDto;
+import CaffeineCoder.recipic.domain.recipe.dto.RecipeResponseDto;
 import CaffeineCoder.recipic.domain.scrap.dao.ScrapRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,32 +21,32 @@ public class RecipeRankService {
         return recipeRepository.findAll();
     }
 
-    public List<RecipeDto> getTop5NormalRecipes() {
+    public List<RecipeResponseDto> getTop5NormalRecipes() {
 
         List<Integer> topRecipeIds = scrapRepository.findTop5NormalRecipesByScrapCount(PageRequest.of(0, 5));
 
-        List<RecipeDto> topRecipes = new ArrayList<>();
+        List<RecipeResponseDto> topRecipes = new ArrayList<>();
 
         for(int i=0; i<topRecipeIds.size(); i++){
             Recipe recipe = recipeRepository.findById(topRecipeIds.get(i)).orElseThrow(() -> new RuntimeException("Recipe not found"));
             int scrapCount = scrapRepository.countByRecipeId(recipe.getRecipeId());
-            topRecipes.add(RecipeDto.fromEntity(recipe, scrapCount));
+            topRecipes.add(RecipeResponseDto.fromEntity(recipe, scrapCount));
         }
 
 
         return topRecipes;
     }
 
-    public List<RecipeDto> getTop5CelebrityRecipes() {
+    public List<RecipeResponseDto> getTop5CelebrityRecipes() {
 
         List<Integer> topRecipeIds = scrapRepository.findTop5CelebrityRecipesByScrapCount(PageRequest.of(0, 5));
 
-        List<RecipeDto> topRecipes = new ArrayList<>();
+        List<RecipeResponseDto> topRecipes = new ArrayList<>();
 
         for(int i=0; i<topRecipeIds.size(); i++){
             Recipe recipe = recipeRepository.findById(topRecipeIds.get(i)).orElseThrow(() -> new RuntimeException("Recipe not found"));
             int scrapCount = scrapRepository.countByRecipeId(recipe.getRecipeId());
-            topRecipes.add(RecipeDto.fromEntity(recipe, scrapCount));
+            topRecipes.add(RecipeResponseDto.fromEntity(recipe, scrapCount));
         }
 
         return topRecipes;

--- a/src/main/java/CaffeineCoder/recipic/domain/recipe/dao/RecipeRepository.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/recipe/dao/RecipeRepository.java
@@ -1,9 +1,28 @@
 package CaffeineCoder.recipic.domain.recipe.dao;
 
 import CaffeineCoder.recipic.domain.recipe.domain.Recipe;
+import CaffeineCoder.recipic.domain.recipe.dto.RecipeDto;
+import CaffeineCoder.recipic.domain.recipe.dto.RecipeResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecipeRepository extends JpaRepository<Recipe, Integer> {
+    @Query("SELECT new CaffeineCoder.recipic.domain.recipe.dto.RecipeDto(" +
+            "r.recipeId, " +
+            "r.userId, " +
+            "r.brandId, " +
+            "r.title, " +
+            "r.description, " +
+            "r.imageUrl, " +
+            "r.isCelebrity, " +
+            "r.createdAt, " +
+            "r.status) " +
+            "FROM Recipe r " +
+            "WHERE r.brandId = :brandId")
+    Page<RecipeDto> findRecipesByBrandId(@Param("brandId") Integer brandId, Pageable pageable);
 }

--- a/src/main/java/CaffeineCoder/recipic/domain/recipe/dto/RecipeDto.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/recipe/dto/RecipeDto.java
@@ -1,36 +1,22 @@
 package CaffeineCoder.recipic.domain.recipe.dto;
 
-import CaffeineCoder.recipic.domain.recipe.domain.Recipe;
+import java.sql.Timestamp;
 
-public record RecipeDto (
-    String recipeId,
-    String userId,
-    String brandId,
+public record RecipeDto(
+    Integer recipeId,
+    Long userId,
+    Integer brandId,
     String title,
     String description,
     String imageUrl,
-    String isCelebrity,
-    String createdAt,
-    String status,
-    int scrapCount
+    Boolean isCelebrity,
+    Timestamp createdAt,
+    Integer status
 ) {
-    public static RecipeDto of(String recipeId, String userId, String brandId, String title, String description, String imageUrl, String isCelebrity, String createdAt, String status,int scrapCount) {
-        return new RecipeDto(recipeId, userId, brandId, title, description, imageUrl, isCelebrity, createdAt, status, scrapCount);
-    }
 
-    //추후 댓글 개수도 추가
-    public static RecipeDto fromEntity(Recipe recipe, int scrapCount) {
-        return new RecipeDto(
-                recipe.getRecipeId().toString(),
-                recipe.getUserId().toString(),
-                recipe.getBrandId().toString(),
-                recipe.getTitle(),
-                recipe.getDescription(),
-                recipe.getImageUrl(),
-                recipe.getIsCelebrity().toString(),
-                recipe.getCreatedAt().toString(),
-                recipe.getStatus().toString(),
-                scrapCount
-        );
+    public static RecipeDto of(Integer recipeId, Long userId, Integer brandId, String title, String description, String imageUrl, Boolean isCelebrity, Timestamp createdAt, Integer status) {
+        return new RecipeDto(recipeId, userId, brandId, title, description, imageUrl, isCelebrity, createdAt, status);
     }
 }
+
+

--- a/src/main/java/CaffeineCoder/recipic/domain/recipe/dto/RecipeResponseDto.java
+++ b/src/main/java/CaffeineCoder/recipic/domain/recipe/dto/RecipeResponseDto.java
@@ -1,0 +1,53 @@
+package CaffeineCoder.recipic.domain.recipe.dto;
+
+import CaffeineCoder.recipic.domain.recipe.domain.Recipe;
+
+import java.sql.Timestamp;
+
+public record RecipeResponseDto(
+    Integer recipeId,
+    Long userId,
+    Integer brandId,
+    String title,
+    String description,
+    String imageUrl,
+    Boolean isCelebrity,
+    Timestamp createdAt,
+    Integer status,
+    Integer scrapCount
+) {
+    public static RecipeResponseDto of(Integer recipeId, Long userId, Integer brandId, String title, String description, String imageUrl, Boolean isCelebrity, Timestamp createdAt, Integer status, Integer scrapCount) {
+        return new RecipeResponseDto(recipeId, userId, brandId, title, description, imageUrl, isCelebrity, createdAt, status, scrapCount);
+    }
+
+    //추후 댓글 개수도 추가
+    public static RecipeResponseDto fromEntity(Recipe recipe, int scrapCount) {
+        return new RecipeResponseDto(
+                recipe.getRecipeId(),
+                recipe.getUserId(),
+                recipe.getBrandId(),
+                recipe.getTitle(),
+                recipe.getDescription(),
+                recipe.getImageUrl(),
+                recipe.getIsCelebrity(),
+                recipe.getCreatedAt(),
+                recipe.getStatus(),
+                scrapCount
+        );
+    }
+    
+    public static RecipeResponseDto fromDto(RecipeDto recipeDto, int scrapCount) {
+        return new RecipeResponseDto(
+                recipeDto.recipeId(),
+                recipeDto.userId(),
+                recipeDto.brandId(),
+                recipeDto.title(),
+                recipeDto.description(),
+                recipeDto.imageUrl(),
+                recipeDto.isCelebrity(),
+                recipeDto.createdAt(),
+                recipeDto.status(),
+                scrapCount
+        );
+    }
+}


### PR DESCRIPTION
### PR 타입 
 - [x] 기능 추가
 - [ ] 기능 삭제
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 🌵
feat/recipe/list ➡️ main

### 작업사항 📝
- 전체 레시피 반환 & 쿼리 기능 구현
- 스크랩 수가 포함된 반환용 DTO 추가

### 신규 API 목록 ✅
`api/recipe/list`: 전체 레시피 반환 (쿼리도 가능)
쿼리파라미터 목록
- keyword: 쿼리 ex)스타벅스
- page: 최신 업로드 기준 내림차순 페이징
- size: 페이지 사이즈

### 테스트 방법 🔎
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/4ef266f2-ea57-4737-b76c-9c0a6a1fba7a">


### 관련 이슈 💡
#7 
